### PR TITLE
Create distinct research for refrigerated cargo bay

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -768,7 +768,8 @@ local technologies = {
       effects = {
           {type = "unlock-recipe", recipe = "preservation-inserter"},
           {type = "unlock-recipe", recipe = "preservation-long-inserter"},
-          {type = "unlock-recipe", recipe = "preservation-stack-inserter"}
+          {type = "unlock-recipe", recipe = "preservation-stack-inserter"},
+          {type = "unlock-recipe", recipe = "preservation-bulk-inserter"}
       },
       order = "a-d-a"
   }
@@ -792,8 +793,7 @@ if mods["space-age"] then
           time = 60
       },
       effects = {
-          {type = "unlock-recipe", recipe = "preservation-platform-warehouse"},
-          {type = "unlock-recipe", recipe = "preservation-bulk-inserter"},
+          {type = "unlock-recipe", recipe = "preservation-platform-warehouse"}
       }
   })
 end

--- a/data.lua
+++ b/data.lua
@@ -774,6 +774,30 @@ local technologies = {
   }
 }
 
+-- Preservation platform-cargo-bay
+if mods["space-age"] then
+  table.insert(technologies, {
+      type = "technology",
+      name = "preservation-platform-warehouse",
+      icons = {{
+          icon = data.raw["cargo-bay"]["cargo-bay"].icon,
+          icon_size = data.raw["cargo-bay"]["cargo-bay"].icon_size,
+          tint = {r=0.6, g=0.8, b=1.0, a=0.8},
+      }},
+      icon_size = 256,
+      prerequisites = {"preservation-warehouse-tech"},
+      unit = {
+          count = 1500,
+          ingredients = ingredPW,
+          time = 60
+      },
+      effects = {
+          {type = "unlock-recipe", recipe = "preservation-platform-warehouse"},
+          {type = "unlock-recipe", recipe = "preservation-bulk-inserter"},
+      }
+  })
+end
+
 
 --[[ ============================================================================
  Register Prototypes
@@ -810,13 +834,3 @@ data:extend(recipes)
 -- Register technologies
 data:extend(technologies)
 
-
--- Add space platform warehouse to space age technology if mod is present
-if mods["space-age"] then
-    table.insert(data.raw["technology"]["space-platform"].effects,
-        {type = "unlock-recipe", recipe = "preservation-platform-warehouse"}
-    )
-    table.insert(data.raw["technology"]["preservation-inserter"].effects,
-        {type = "unlock-recipe", recipe = "preservation-bulk-inserter"}
-    )
-end

--- a/locale/de/base.cfg
+++ b/locale/de/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=Logistik-Kühlschrank
 preservation-warehouse-tech=Gefrierlager-Technologie
 preservation-wagon=Kühlwagen-Technologie
 preservation-inserter=Konservierungs-Greifarm-Technologie
+preservation-platform-warehouse=Weltraum-Gefrierlager-Technologie
 
 [item-description]
 refrigerater=Nuklearbetriebener Kühlschrank, verlangsamt die Verderblichkeit von Gegenständen um den Faktor 20 (Standard) oder Ihre benutzerdefinierten Raten

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=logistic-refrigerator
 preservation-warehouse-tech=Freezing Warehouse Technology
 preservation-wagon=Preservation Wagon Technology
 preservation-inserter=Preservation Inserter Technology
+preservation-platform-warehouse=Freezing Cargo Bay
 
 [item-description]
 refrigerater=Nuclear-powered refrigerator, slows the spoilage of items by a factor of 20(default) or your custom rates

--- a/locale/es/base.cfg
+++ b/locale/es/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=Refrigerador logístico
 preservation-warehouse-tech=Tecnología de almacén de congelación
 preservation-wagon=Tecnología de vagón de preservación
 preservation-inserter=Tecnología de insertador de preservación
+preservation-platform-warehouse=Tecnología de almacén de congelación espacial
 
 [item-description]
 refrigerater=Refrigerador nuclear, ralentiza el deterioro de los objetos por un factor de 20 (por defecto) o según tus tasas personalizadas

--- a/locale/fr/base.cfg
+++ b/locale/fr/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=Réfrigérateur logistique
 preservation-warehouse-tech=Technologie d'entrepôt frigorifique
 preservation-wagon=Technologie de wagon de préservation
 preservation-inserter=Technologie de bras robotisé de préservation
+preservation-platform-warehouse=Technologie d'etrepôt frigorifique spatial
 
 [item-description]
 refrigerater=Réfrigérateur nucléaire, ralentit la détérioration des objets par un facteur de 20 (par défaut) ou selon vos taux personnalisés

--- a/locale/it/base.cfg
+++ b/locale/it/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=Frigorifero logistico
 preservation-warehouse-tech=Tecnologia magazzino frigorifero
 preservation-wagon=Tecnologia vagone di conservazione
 preservation-inserter=Tecnologia inseritore di conservazione
+preservation-platform-warehouse=Tecnologia magazzino frigorifero spaziale
 
 [item-description]
 refrigerater=Frigorifero nucleare, rallenta il deterioramento degli oggetti di un fattore 20 (predefinito) o secondo le tue impostazioni personalizzate

--- a/locale/ja/base.cfg
+++ b/locale/ja/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=物流冷蔵庫
 preservation-warehouse-tech=冷凍倉庫技術
 preservation-wagon=保冷車両技術
 preservation-inserter=保存インサータ技術
+preservation-platform-warehouse=宇宙冷凍倉庫技術
 
 [item-description]
 refrigerater=原子力冷蔵庫、アイテムの劣化を20倍（デフォルト）またはカスタム設定した倍率で遅くします

--- a/locale/ko/base.cfg
+++ b/locale/ko/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=물류 냉장고
 preservation-warehouse-tech=냉동 창고 기술
 preservation-wagon=보존 화물차 기술
 preservation-inserter=보존 투입기 기술
+preservation-platform-warehouse=우주 냉동 창고 기술
 
 [item-description]
 refrigerater=핵동력 냉장고, 아이템의 부패를 20배(기본값) 또는 사용자 지정 비율로 늦춥니다

--- a/locale/pl/base.cfg
+++ b/locale/pl/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=Lodówka logistyczna
 preservation-warehouse-tech=Technologia magazynu chłodniczego
 preservation-wagon=Technologia wagonu chłodniczego
 preservation-inserter=Technologia podajnika konserwującego
+preservation-platform-warehouse=Technologia kosmiczny magazyn chłodniczy
 
 [item-description]
 refrigerater=Lodówka nuklearna, spowalnia psucie się przedmiotów o współczynnik 20 (domyślnie) lub według własnych ustawień

--- a/locale/pt-BR/base.cfg
+++ b/locale/pt-BR/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=Geladeira logística
 preservation-warehouse-tech=Tecnologia de armazém frigorífico
 preservation-wagon=Tecnologia de vagão de preservação
 preservation-inserter=Tecnologia de insersor de preservação
+preservation-platform-warehouse=Tecnologia de armazém frigorífico espacial
 
 [item-description]
 refrigerater=Geladeira nuclear, retarda a deterioração dos itens por um fator de 20 (padrão) ou suas taxas personalizadas

--- a/locale/ru/base.cfg
+++ b/locale/ru/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=Логистический холодильник
 preservation-warehouse-tech=Технология морозильного склада
 preservation-wagon=Технология вагона-холодильника
 preservation-inserter=Технология манипулятора сохранения
+preservation-platform-warehouse=Технология kосмический морозильный склад
 
 [item-description]
 refrigerater=Ядерный холодильник, замедляет порчу предметов в 20 раз (по умолчанию) или согласно вашим настройкам

--- a/locale/zh-CN/base.cfg
+++ b/locale/zh-CN/base.cfg
@@ -50,6 +50,7 @@ logistic-refrigerater=物流冰箱
 preservation-warehouse-tech=冷藏仓库技术
 preservation-wagon=冷藏车厢技术
 preservation-inserter=保鲜机械臂技术
+preservation-platform-warehouse=太空冷冻仓库技术
 
 [item-description]
 refrigerater=核能冰箱，将物品腐坏速度减慢20倍（默认）或自定义比率


### PR DESCRIPTION
This fixes an issue for players (me) who added this mod on an existing save.

- For existing saves where space platform was already researched, there is no way to retroactively unlock cargo bay
- On new saves, refrigerated cargo bay is unlocked as part of space-platform, however the cargo bay cannot be crafted until the freezer warehouse is unlocked by research much later

Breaking it out to a separate research (dependent on freezer warehouse) resolves the dependency, and also makes the mode safe to apply on existing saves.